### PR TITLE
Dashboard renders childcomponents

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,20 @@
 import React from "react";
 import Dashboard from "aero-ui/Dashboard";
+import Link from "@material-ui/core/Link";
+import Typography from "@material-ui/core/Typography";
 
-const App = () => <Dashboard />;
+const UvicAero = () => {
+  return (
+    <Typography variant="body2" color="textSecondary" align="center">
+      {"UVic Aero"}
+      <Link color="inherit" href="https://uvicaero.com/" target="_blank">
+        UVic Aero
+      </Link>
+      {" team."}
+    </Typography>
+  );
+};
+
+const App = () => <Dashboard>{UvicAero()}</Dashboard>;
 
 export default App;

--- a/src/aero-ui/Dashboard.js
+++ b/src/aero-ui/Dashboard.js
@@ -109,7 +109,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-export default function Dashboard() {
+const Dashboard = props => {
   const classes = useStyles();
   const [open, setOpen] = React.useState(true);
   const handleDrawerOpen = () => {
@@ -169,8 +169,11 @@ export default function Dashboard() {
         <Container maxWidth="lg" className={classes.container}>
           <Grid container spacing={3} />
         </Container>
-        <UvicAero />
+        {/** CHILD COMPONENTS */}
+        {props.children}
       </main>
     </div>
   );
-}
+};
+
+export default Dashboard;


### PR DESCRIPTION
Git issue: https://github.com/uvic-aero/dt-client/issues/15

# Overview
Making it so the Dashboard component can be passed child components.

Tested with creating the `UVicAero` component which renders some typography and is passed to the `Dashboard` component.